### PR TITLE
Rename ValveControl to RelayControl

### DIFF
--- a/src/cal.cpp
+++ b/src/cal.cpp
@@ -25,18 +25,18 @@
 #include <algorithm>
 #include <sys/stat.h>
 
-void iCalValveControl::add_to_list(icaltimetype start, icaltimetype end)
+void iCalRelayControl::add_to_list(icaltimetype start, icaltimetype end)
 {
     struct icaltime_span ts = icaltime_span_new(start,end,1);
 	this->events.push_back(ts);
 }
 
-void iCalValveControl::sort_events()
+void iCalRelayControl::sort_events()
 {
 
 }
 
-bool iCalValveControl::IsActive() {
+bool iCalRelayControl::IsActive() {
     time_t now = time(0);
     auto v = find_if(std::begin(events), std::end(events),
        [now](const icaltime_span &ts) {
@@ -46,7 +46,7 @@ bool iCalValveControl::IsActive() {
 }
 
 // Parse calendar information from the string
-int iCalValveControl::ParseICALFromString(const string &ical)
+int iCalRelayControl::ParseICALFromString(const string &ical)
 {
 	DEBUG_PRINT(LOG_DEBUG, "INFO: Parsing schedule\n");
 
@@ -159,7 +159,7 @@ int iCalValveControl::ParseICALFromString(const string &ical)
 }
 
 // Load and parse calendar information from file
-int iCalValveControl::ParseICALFromFile(string file_name)
+int iCalRelayControl::ParseICALFromFile(string file_name)
 {
     ifstream f(file_name);
     string ln;

--- a/src/cal.h
+++ b/src/cal.h
@@ -44,16 +44,16 @@ enum grass_type_t {
 	GT_TREES
 };
 
-class IValveControl
+class IRelayControl
 {
 public:
 	virtual bool IsActive() = 0;
 };
 
-class iCalValveControl: IValveControl
+class iCalRelayControl: IRelayControl
 {
 public:
-	iCalValveControl(grass_type_t grass_type): gt(grass_type), last_updated(0) {};
+	iCalRelayControl(grass_type_t grass_type): gt(grass_type), last_updated(0) {};
 
 	// Parse calendar information from the string
 	int ParseICALFromString(const string &ical);

--- a/src/channel.h
+++ b/src/channel.h
@@ -25,7 +25,7 @@ using namespace std;
 // Type declaration
 struct channel_t
 {
-    iCalValveControl vc;
+    iCalRelayControl vc;
     GpioRelay gpio;
     const string url;
 


### PR DESCRIPTION
All the occurences of iCalValveControl and IValveControl have been
replaced with iCalRelayControl and IRelayControl respectively.
Occurences were found by grepping. Successfully passed build tests.

Closes Refactoring #3.
